### PR TITLE
Implement dynamic transient based on parsed targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.DEFAULT_GOAL := help
+
+.PHONY: test
+test: test-unit ## Launch all the tests (unit, functional and integration)
+
+.PHONY: test-unit
+test-unit: ## Launch the unit tests
+	emacs -batch -L . -l t/conf.el -l ert -l t/test-gazr.el -f ert-run-tests-batch
+	@echo "Unit Testing..."
+
+.PHONY: help
+help:  ## Display command usage
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Using [straight.el](https://github.com/raxod502/straight.el):
     :straight (gazr :type git :host github :repo "volnt/gazr.el")
     :bind (("C-c C-g" . gazr)))
 ```
+## Dependencies
+
+* [transient](https://github.com/magit/transient)
+* [trie](https://github.com/emacsmirror/trie)
 
 ## Usage
 

--- a/t/conf.el
+++ b/t/conf.el
@@ -1,0 +1,13 @@
+(require 'package)
+(setq package-user-dir (expand-file-name "./.packages"))
+(setq package-archives '(("melpa" . "https://melpa.org/packages/")
+                         ("elpa" . "https://elpa.gnu.org/packages/")))
+
+;; Initialize the package system
+(package-initialize)
+(unless package-archive-contents
+  (package-refresh-contents))
+
+;; Install dependencies
+(package-install 'trie)
+(package-install 'transient)

--- a/t/test-gazr.el
+++ b/t/test-gazr.el
@@ -1,0 +1,17 @@
+(require 'ert)
+(require 'gazr)
+
+(ert-deftest extract-words-first-letters ()
+  (should (equal (gazr--extract-words-first-letters "foobar") "f"))
+  (should (equal (gazr--extract-words-first-letters "foo-bar") "fb"))
+  (should (equal (gazr--extract-words-first-letters "foo-bar-lol") "fbl")))
+  (should (equal (gazr--extract-words-first-letters "foo--bar") "fb"))
+  (should (equal (gazr--extract-words-first-letters "-") nil))
+  (should (equal (gazr--extract-words-first-letters "") nil))
+
+(ert-deftest parse-makefile-targets ()
+  (should (equal (gazr--parse-makefile-targets ".PHONY: foo\nfoo:\n") (list "foo")))
+  (should (equal (gazr--parse-makefile-targets "") (list)))
+  (should (equal (gazr--parse-makefile-targets ".PHONY: foo foo\n") (list "foo")))
+  (should (equal (gazr--parse-makefile-targets ".PHONY: foo") (list "foo")))
+  (should (equal (gazr--parse-makefile-targets ".PHONY: foo bar lol\n") (list "foo" "bar" "lol"))))


### PR DESCRIPTION
Implement dynamic transient that parses the Makefile targets and creates prefixes accordingly.

The targets are parsed from `.PHONY` targets only.

The target prefixes can be represented like a tree. With each target being a leaf and each not-last-word being a branch. In other words it's a [trie](https://en.wikipedia.org/wiki/Trie) of words.

Example:

```
root/
├─ (t) test/
│  ├─ (u) test-unit
│  ├─ (i) test-integration
│  ├─ (t) test
├─ (b) build
├─ (i) init

``` 